### PR TITLE
Remove unused dependencies and compile options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,6 @@ option(BUILD_SHARED_LIBS "Build shared libraries" OFF) # needed for fftw to not 
 #CPMAddPackage("https://math.ryerson.ca/~lkolasa/xxx.tar.gz") # Not online anymore (2022). Now directly included in this repository.
 CPMAddPackage("gh:juce-framework/JUCE#6.1.6")
 CPMAddPackage("https://www.fftw.org/fftw-3.3.10.tar.gz#MD5=8ccbf6a5ea78a16dbc3e1306e234cc5c")
-CPMAddPackage("gh:dmoulding/vld#v1.9h")
 CPMAddPackage("gh:tcbrindle/span#117fbada0f888e1535e3db20c7c9ddd86db129e2")
 # CPMAddPackage("gh:Neargye/magic_enum#v0.8.0") # simplifies enum handling, not yet needed
 

--- a/README.md
+++ b/README.md
@@ -113,11 +113,6 @@ any changes that have been made.  Use for commercial applications is only
 allowed by permission of the copyright holders.
 "
 
-- Visual Leak Detector (VLD)   
-(c) 2005-2011 Dan Moulding, Arkadiy Shapkin, Laurent Lessieux   
-https://github.com/dmoulding/vld   
-GNU Lesser General Public License v2.1
-
 - Implementation of C++20's std::span for older compilers
 (c) 2019 by Tristan Brindle
 https://github.com/tcbrindle/span

--- a/cmake/CompilerOptions.cmake
+++ b/cmake/CompilerOptions.cmake
@@ -36,10 +36,11 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
     list(APPEND SANITIZERS "thread")
 endif()
 
-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|AppleClang")
-    # Memory Sanatizer
-    list(APPEND SANITIZERS "memory")
-endif()
+# The Memory Sanatizer is only supported by Clang for Linux. 
+# Since GNU C++ is used for Linux, it will never be used.
+#if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+#    list(APPEND SANITIZERS "memory")
+#endif()
 
 list(JOIN SANITIZERS ";-fsanitize=" LIST_OF_SANITIZERS)
 if((LIST_OF_SANITIZERS) AND (NOT "${LIST_OF_SANITIZERS}" STREQUAL ""))


### PR DESCRIPTION
**Changes:**
- Remove unused dependency to deprecated library VLD (Visual Leak Detector)
- Remove "memory" sanitizer since it only works with CLang on Linux, which isn't used.