### PR TITLE
Use Renovate to update CPM managed dependencies 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,10 +43,9 @@ option(BUILD_SHARED_LIBS "Build shared libraries" OFF) # needed for fftw to not 
 
 # Import dependencies
 #CPMAddPackage("https://math.ryerson.ca/~lkolasa/xxx.tar.gz") # Not online anymore (2022). Now directly included in this repository.
-CPMAddPackage("gh:juce-framework/JUCE#7.0.0")
-CPMAddPackage("https://www.fftw.org/fftw-3.3.10.tar.gz#MD5=8ccbf6a5ea78a16dbc3e1306e234cc5c")
-CPMAddPackage("gh:tcbrindle/span#117fbada0f888e1535e3db20c7c9ddd86db129e2")
-# CPMAddPackage("gh:Neargye/magic_enum#v0.8.0") # simplifies enum handling, not yet needed
+CPMGetPackage(JUCE)
+CPMGetPackage(fftw)
+CPMGetPackage(span)
 
 # If you've installed JUCE somehow (via a package manager, or directly using the CMake install
 # target), you'll need to tell this project that it depends on the installed copy of JUCE. If you've

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -33,3 +33,13 @@ ctest --test-dir build/test
 ```
 
 [CTest](https://cmake.org/cmake/help/latest/manual/ctest.1.html)
+
+### Create and update package-lock.cmake
+As described in [CPM Package-lock](https://github.com/cpm-cmake/CPM.cmake/wiki/Package-lock), `package-lock.cmake` can be created and updated using the following commands. 
+
+```shell
+cmake -H. -Bbuild
+cmake --build build --target cpm-update-package-lock 
+```
+
+The advantage of this approach is that there is one distinct file that contains all dependencies and versions. [Renovate](https://github.com/renovatebot/renovate) is used to update those dependencies automatically as configured in [renovate.json](./renovate.json).

--- a/cmake/Environment.cmake
+++ b/cmake/Environment.cmake
@@ -21,6 +21,7 @@ if(NOT (EXISTS ${CPM_DOWNLOAD_LOCATION}))
     file(DOWNLOAD https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake ${CPM_DOWNLOAD_LOCATION})
 endif()
 include(${CPM_DOWNLOAD_LOCATION})
+CPMUsePackageLock(package-lock.cmake)
 
 #Minimum MacOS target, set globally
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13" CACHE STRING "Minimum OS X deployment version" FORCE)

--- a/package-lock.cmake
+++ b/package-lock.cmake
@@ -7,11 +7,11 @@ CPMDeclarePackage(JUCE
   GITHUB_REPOSITORY juce-framework/JUCE
   EXCLUDE_FROM_ALL YES
 )
-# fftw
+# fftw (download links need to be updated manually on version updates)
 CPMDeclarePackage(fftw
   URL https://www.fftw.org/fftw-3.3.10.tar.gz URL_HASH MD5=8ccbf6a5ea78a16dbc3e1306e234cc5c EXCLUDE_FROM_ALL YES
 )
-# span (unversioned)
+# span (unversioned)(commits need to be updated manually on version updates)
 CPMDeclarePackage(span
  GIT_TAG 117fbada0f888e1535e3db20c7c9ddd86db129e2
  GITHUB_REPOSITORY tcbrindle/span

--- a/package-lock.cmake
+++ b/package-lock.cmake
@@ -1,0 +1,26 @@
+# CPM Package Lock
+# This file should be committed to version control
+
+# JUCE
+CPMDeclarePackage(JUCE
+  GIT_TAG 7.0.0
+  GITHUB_REPOSITORY juce-framework/JUCE
+  EXCLUDE_FROM_ALL YES
+)
+# fftw
+CPMDeclarePackage(fftw
+  URL https://www.fftw.org/fftw-3.3.10.tar.gz URL_HASH MD5=8ccbf6a5ea78a16dbc3e1306e234cc5c EXCLUDE_FROM_ALL YES
+)
+# span (unversioned)
+CPMDeclarePackage(span
+ GIT_TAG 117fbada0f888e1535e3db20c7c9ddd86db129e2
+ GITHUB_REPOSITORY tcbrindle/span
+ EXCLUDE_FROM_ALL YES
+)
+
+# Catch2
+CPMDeclarePackage(Catch2
+  VERSION 3.0.1
+  GITHUB_REPOSITORY catchorg/Catch2
+  EXCLUDE_FROM_ALL YES
+)

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,34 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base",
-    "schedule:earlyMondays"
+    "schedule:earlyMondays",
+    ":combinePatchMinorReleases",
+    ":ignoreUnstable"
   ],
-  "baseBranches": ["main", "feature/renovate-for-cpm"]
+  "regexManagers": [
+    {
+      "fileMatch": ["(^|/)package-lock\\.cmake$"],
+      "matchStrings": [
+        "CPMDeclarePackage\\(\\w+\\s+GIT_TAG\\s+(?<currentValue>.*?)\\s+GITHUB_REPOSITORY\\s+\"?(?<depName>.*?)\"?\\s+"
+      ],
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "fileMatch": ["(^|/)package-lock\\.cmake$"],
+      "matchStrings": [
+        "CPMDeclarePackage\\(\\w+\\s+VERSION\\s+(?<currentValue>.*?)\\s+GITHUB_REPOSITORY\\s+\"?(?<depName>.*?)\"?\\s+"
+      ],
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v?(?<version>.*?)$"
+    },
+    {
+      "fileMatch": ["(^|/)\\w+\\.cmake$", "(^|/)CMakeLists.cmake$"],
+      "matchStrings": [
+        "https:\\/\\/github\\.com\\/(?<depName>[^{}]*?)\\/releases\\/download\\/(?<currentValue>[^{}]*?)\\/",
+        "#*https:\\/\\/github\\.com\\/(?<depName>[^{}]*?)\\s+.*VERSION\\w*\\s+(?<currentValue>[^{}]*?)\\s*\\)"
+      ],
+      "datasourceTemplate": "github-releases"
+    }
+  ]
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,7 +6,7 @@ set(TEST_PROJECT_NAME "${PROJECT_NAME}Tests")
 
 # Import test dependencies
 # Needs CPM which comes from "Environment.cmake" in the root directory of this repository
-CPMAddPackage("gh:catchorg/Catch2@3.0.1")
+CPMGetPackage(Catch2)
 
 # Enable testing with Catch2
 enable_testing()


### PR DESCRIPTION
### Changes:
- Use Renovate to update CPM managed dependencies 