### PR TITLE
Support CMake version 4.x

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -68,7 +68,7 @@ jobs:
         xcode-version: latest-stable
 
     - name: Get latest CMake
-      uses: lukka/get-cmake@latest      
+      uses: lukka/get-cmake@v4.0.1
 
     - name: Checkout code
       uses: actions/checkout@v4

--- a/fftw-update-min-cmake.patch
+++ b/fftw-update-min-cmake.patch
@@ -1,0 +1,10 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b6e4666..ea826f9 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required (VERSION 3.0)
++cmake_minimum_required (VERSION 3.15)
+ 
+ if (NOT DEFINED CMAKE_BUILD_TYPE)
+   set (CMAKE_BUILD_TYPE Release CACHE STRING "Build type")

--- a/package-lock.cmake
+++ b/package-lock.cmake
@@ -9,7 +9,10 @@ CPMDeclarePackage(JUCE
 )
 # fftw (download links need to be updated manually on version updates)
 CPMDeclarePackage(fftw
-  URL https://www.fftw.org/fftw-3.3.10.tar.gz URL_HASH MD5=8ccbf6a5ea78a16dbc3e1306e234cc5c EXCLUDE_FROM_ALL YES
+  URL https://www.fftw.org/fftw-3.3.10.tar.gz
+  URL_HASH MD5=8ccbf6a5ea78a16dbc3e1306e234cc5c
+  EXCLUDE_FROM_ALL YES
+  PATCHES "fftw-update-min-cmake.patch"
 )
 # span (unversioned)(commits need to be updated manually on version updates)
 CPMDeclarePackage(span


### PR DESCRIPTION
- [Support CMake version 4.x](https://github.com/JohT/speclet/pull/82/commits/cb848fb2da18105730cfe3b7e55eab880279198c)  
- Patch `cmake_minimum_required` of external lib `fftw` due to removed compatibility to cmake < 3.5